### PR TITLE
Problem with textmate

### DIFF
--- a/lib/qwandry/launcher.rb
+++ b/lib/qwandry/launcher.rb
@@ -70,7 +70,7 @@ module Qwandry
       end
       
       paths = package.is_a?(String) ? [package] : package.paths
-      system editor, *paths
+      system "#{editor} #{paths.join ' '}"
     end
     
     private


### PR DESCRIPTION
Hi Adam,

First, let me tell you, Qwandry is great! I use the textmate, and my EDITOR export is "mate -w", so that I can edit my git commits in mate for example. Qwandry does not work in this configuration. I have made a small modification to it so that this can be supported. Would you mind pulling it? Thanks,
- Bernard
