### PR TITLE
Python 3 support for Qwandry::Launcher::configure_repositories

### DIFF
--- a/lib/qwandry/launcher.rb
+++ b/lib/qwandry/launcher.rb
@@ -102,7 +102,7 @@ module Qwandry
       end
       
       # add python repositories:
-      python_paths = `python -c 'import sys;print \"\\n\".join(sys.path)'` rescue ''
+      python_paths = `python -c 'import sys;print(\"\\n\".join(sys.path))'` rescue ''
       python_paths.split("\n").reject{|path| path == '' || path == '.' || path =~ /\.zip$/ || path =~/lib-dynload$/}.each do |path|
         add :python, path, :class=>Qwandry::LibraryRepository, :reject => /\.(py[oc])|(egg-info)$/
       end


### PR DESCRIPTION
Simple fix to make it not crash when default Python interpreter is version 3.
