### PR TITLE
Pass editor exit status to shell

### DIFF
--- a/bin/qw
+++ b/bin/qw
@@ -84,4 +84,8 @@ else
   package = packages[index]
 end
 
-@qwandry.launch(package) if package
+if package
+  if not @qwandry.launch(package)
+    exit 1
+  end
+end


### PR DESCRIPTION
Here's another small change: at the end of qw, check the return value of Qwandry::Launcher::launch() and "exit 1" if it's false or nil, indicating that the system() call in launch() failed somehow.
