### PR TITLE
Issue #17 Fix

### DIFF
--- a/lib/qwandry/configuration.rb
+++ b/lib/qwandry/configuration.rb
@@ -23,7 +23,7 @@ module Qwandry
       
       # Returns true if binary `name` is present.
       def present? name
-        system("which #{name}", STDOUT=>"/dev/null")
+        system("which #{name} > /dev/null")
       end
       
       # Sets the default configuration to launch, if no `configurations` are passed


### PR DESCRIPTION
Adam,

Just a quick fix to address Issue #17, Can't convert Hash into String. 

I simply changed the call to redirect output to /dev/null in the command itself. This works in Ruby 1.8 and 1.9.

Thanks,
Kevin
