### PR TITLE
Find gems in RVM gemsets when using @global and a @perproject gemset.

### DIFF
--- a/lib/qwandry/configuration/default.rb
+++ b/lib/qwandry/configuration/default.rb
@@ -11,15 +11,8 @@ end
 register_if_present :gem do
   require 'rubygems' unless defined? Gem
   
-  paths = []
-  if ENV['GEM_PATH']  # RVM makes use of GEM_PATH
-    paths = ENV['GEM_PATH'].split(':').map { |p| File.join(p, 'gems') }
-  end
-  paths << File.join(Gem.dir, 'gems')
-  paths = paths.uniq  # Possible duplicates from GEM_PATH and Gem.dir
-
   # Add rubygems path:
-  add paths
+  add Gem.path.map { |p| File.join(p, 'gems') }
 end
 
 # Register a perl configuration:


### PR DESCRIPTION
Hi,

RVM allows for the use of gemsets in order to allow multiple projects that you may be working on have their own set of gems.  In addition, there is also the possibility to use the @global gemset.

In this case, the GEM_PATH would have a colon-separated list of paths to these multiple gemsets.  It appears that Gem.dir only provides a single path, the @perproject gemset, but not the @global gemset.

This patch will include paths in GEM_PATH and Gem.dir and remove any duplicates between the two.

RIck
