### PR TITLE
Update Configuration to manually search for binary

### DIFF
--- a/lib/qwandry/configuration.rb
+++ b/lib/qwandry/configuration.rb
@@ -23,7 +23,10 @@ module Qwandry
       
       # Returns true if binary `name` is present.
       def present? name
-        system("which #{name} > /dev/null")
+        return File.exist?(name.to_s) ||
+                  ENV['PATH'].split(File::PATH_SEPARATOR).find {|pathDir|
+                    File.exist?(File.join pathDir, name.to_s)
+                  }
       end
       
       # Sets the default configuration to launch, if no `configurations` are passed


### PR DESCRIPTION
Updated Configuration#present? to manually look for binary file instead of shelling out to which. This is more friendly for Windows users; they may not have which.exe installed, and redirecting to /dev/null behaves differently (if \dev directory exists, stdout written to a file named null; if not, results in 'the system cannot find the file specified').
