### PR TITLE
Support searches inside packages (issue #32)

### DIFF
--- a/lib/qwandry/launcher.rb
+++ b/lib/qwandry/launcher.rb
@@ -7,6 +7,11 @@ module Qwandry
     
     # Searches all of the loaded repositories for `name`
     def find(*pattern)
+      if pattern[0].include? '/'
+        # Perform a deep scan if the first token of the pattern contains a slash
+        pattern[0], deep_scan_pattern = pattern[0].split('/', 2)
+      end
+      
       # Create a glob pattern from the user's input, for instance
       # ["rails","2.3"] => "rails*2.3*"
       pattern = pattern.join('*')
@@ -19,6 +24,17 @@ module Qwandry
       end
       
       differentiate packages
+
+      if deep_scan_pattern
+        # Deep scan all matched packages
+        packages = packages.inject([]) do |matched_paths, package|
+          matched_paths += package.deep_scan(deep_scan_pattern)
+        end
+
+        # Sort by length of the matched paths, with the shortest one last
+        packages.sort_by! { |package| -package.paths.first.size }
+      end
+
       packages
     end
   

--- a/lib/qwandry/package.rb
+++ b/lib/qwandry/package.rb
@@ -9,5 +9,24 @@ module Qwandry
       @repository = repository
       @paths = paths
     end
+
+    # Look for matched paths inside the package
+    def deep_scan(pattern)
+      packages = []
+
+      paths.each do |path|
+        Dir.glob("#{path}/**/*").each do |matched_path|
+          # Match against the full path from the package root
+          package_path = matched_path.gsub(%r{^#{Regexp.escape path}/}, '')
+
+          if File.fnmatch("*#{pattern}*", package_path)
+            # Wrap the matched paths in a new Package, adding the original package name
+            packages << Package.new("#{name}/#{package_path}", [ matched_path ], repository)
+          end
+        end
+      end
+
+      packages
+    end
   end
 end


### PR DESCRIPTION
Some comments:
- I quickly scrapped the idea with using `require` since that's Ruby specific, and it might not be the best idea to load random code anyway ;-)
- Instead I added a `deep_scan` method on `Qwandry::Package`, so it will work with packages found by any repository
- I'd say adding an option for this isn't necessary, since the presence of a slash already indicates a deep search, and package names can't include slashes anyway
- I've only tested this with the Ruby core library and gems, but the approach should work for NodeJS / Perl as well
- Wildcards are added around the path pattern, so it will easily match paths deep inside the package as well
- If multiple matches are found the user will be presented with a choice as usual, also showing package versions if necessary since `differentiate` is called before performing the deep search

To check out the behaviour try `rake/task` and `test/unit`, or even `test/` ;-)

Let me know what you think, I'll also update the README once we agree on the behaviour.
