### PR TITLE
Add ability to print package path

### DIFF
--- a/bin/qw
+++ b/bin/qw
@@ -10,8 +10,10 @@ require "qwandry.rb"
 config = Qwandry::Configuration
 config.load_configuration_files
 
-# Create a launcher
-@launcher = Qwandry::Launcher.new
+# By default, Qwandry opens the given package
+# in an editor
+require 'qwandry/actions/launch_package'
+@action = Qwandry::Actions::LaunchPackage.new
 
 opts = OptionParser.new do |opts|    
   opts.banner = "Usage: qwandry [options] name"
@@ -23,7 +25,12 @@ opts = OptionParser.new do |opts|
   
   opts.separator ""
   opts.on("-e", "--editor EDITOR", "Use EDITOR to open the package") do |editor|
-    @launcher.editor = editor
+    @action.editor = editor
+  end
+  
+  opts.on("-s", "--show", "Show package path") do
+    require 'qwandry/actions/show_package_path'
+    @action = Qwandry::Actions::PrintPackagePath.new
   end
   
   opts.separator "Additional Commands"
@@ -67,7 +74,8 @@ end
 
 # Find the packages:
 name = ARGV.join(' ')
-packages = @launcher.find(*ARGV)
+finder = Qwandry::Launcher.new
+packages = finder.find(*ARGV)
 ARGV.clear # for the gets below
 
 # There may be 0, 1, or many matches.  If many, then
@@ -89,13 +97,9 @@ else
   package = packages[index]
 end
 
-# If there is a package, then launch it.
 if package
-  if @launcher.launch(package)
-    # Exit code 0 for success
-    exit 0 
-  else
-    # Exit with the status returned by the process used to open the package
-    exit $?.exitstatus 
-  end
+  @action.package = package
+  @action.run
+  
+  exit @action.exit_status
 end

--- a/lib/qwandry/action/success_exitstatus.rb
+++ b/lib/qwandry/action/success_exitstatus.rb
@@ -1,0 +1,9 @@
+module Qwandry
+  module Action
+    module SuccessExitstatus
+      def success_exitstatus
+        0
+      end
+    end
+  end
+end

--- a/lib/qwandry/actions/launch_package.rb
+++ b/lib/qwandry/actions/launch_package.rb
@@ -1,0 +1,37 @@
+require 'qwandry/action/success_exitstatus'
+
+module Qwandry
+  module Actions
+    # Opens package in an editor
+    class LaunchPackage
+      include Qwandry::Action::SuccessExitstatus
+
+      attr_accessor :package
+      attr_accessor :editor
+
+      attr_accessor :exit_status
+
+      def run
+        self.exit_status = if launch_package
+          success_exitstatus
+        else
+          # Exit with the status returned by the process used to open the package
+          last_child_process_exitstatus
+        end
+      end
+      
+      private
+      
+      def launch_package
+        launcher = Qwandry::Launcher.new
+        launcher.editor = editor
+        
+        launcher.launch(package)
+      end
+      
+      def last_child_process_exitstatus
+        $?.exitstatus
+      end
+    end
+  end
+end

--- a/lib/qwandry/actions/show_package_path.rb
+++ b/lib/qwandry/actions/show_package_path.rb
@@ -1,0 +1,17 @@
+require 'qwandry/action/success_exitstatus'
+
+module Qwandry
+  module Actions
+    class PrintPackagePath
+      include Qwandry::Action::SuccessExitstatus
+
+      attr_accessor :package
+
+      def run
+        puts package.paths
+      end
+      
+      alias_method :exit_status, :success_exitstatus # Assuming puts always succeeds
+    end
+  end
+end


### PR DESCRIPTION
Pass the `--show` (or `-s`) flag to print the package's path instead of launching it in an editor. Inspired by `bundle show`.
